### PR TITLE
Fix mulibyte saving on Ruby 1.9

### DIFF
--- a/lib/oklahoma_mixer/hash_database.rb
+++ b/lib/oklahoma_mixer/hash_database.rb
@@ -372,7 +372,7 @@ module OklahomaMixer
     
     def cast_to_bytes_and_length(object)
       bytes = object.to_s
-      [bytes, bytes.length]
+      [bytes, bytes.bytesize]
     end
     alias_method :cast_key_in,   :cast_to_bytes_and_length
     alias_method :cast_value_in, :cast_to_bytes_and_length

--- a/test/core_database/getting_and_setting_keys_test.rb
+++ b/test/core_database/getting_and_setting_keys_test.rb
@@ -1,3 +1,4 @@
+# Encoding: UTF-8
 require "test_helper"
 require "shared/storage_tests"
 
@@ -16,6 +17,14 @@ class TestGettingAndSettingKeys < Test::Unit::TestCase
   def test_a_key_value_pair_can_be_stored_and_fetched_from_the_database
     assert_equal("value", @db.store("key", "value"))
     assert_equal("value", @db.fetch("key"))  # later
+  end
+  
+  def test_a_multibyte_key_is_saved_in_full_on_19
+    # This only applies to Ruby 1.9
+    if '1.9'.respond_to? :encoding
+      assert_equal("value", @db.store("あいうえお", "value"))
+      assert_equal("あいうえお", @db.keys[0].force_encoding('UTF-8'))
+    end
   end
   
   def test_both_keys_and_values_are_converted_to_strings


### PR DESCRIPTION
I was using OKMixer in a Ruby 1.9 project and ran into this problem with some multibyte strings when used as keys. The TODO said 1.9 support was coming, so I hope this can help towards that.

Multibyte strings were being stored with an incorrect length on Ruby 1.9 because .length returns characters and not bytes.

For example, あいうえお would be stored as \xE3\x81\x82\xE3\x81 instead of the correct \xE3\x81\x82\xE3\x81\x84\xE3\x81\x86\xE3\x81\x88\xE3\x81\x8A.

Thanks for a great library!
Kim
